### PR TITLE
fix: sse 사용 하면서 생기는 hikari pool 고갈 현상 수정

### DIFF
--- a/src/main/java/com/example/density_check_web_service/NotifyController.java
+++ b/src/main/java/com/example/density_check_web_service/NotifyController.java
@@ -2,12 +2,14 @@ package com.example.density_check_web_service;
 
 import com.example.density_check_web_service.domain.Notify.NotifyRepository;
 import com.example.density_check_web_service.domain.Notify.dto.NotifyDto;
+import com.example.density_check_web_service.domain.Users.UsersRepository;
 import com.example.density_check_web_service.service.NotifyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -21,8 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
 public class NotifyController {
     private final NotifyService notifyService;
 
-    public static Map<Long, SseEmitter> sseEmitters = new ConcurrentHashMap<>();
-
     @ResponseBody
     @GetMapping(value = "/sub", produces = "text/event-stream")
     public SseEmitter subscribe(Authentication authentication,
@@ -30,17 +30,19 @@ public class NotifyController {
 
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
         String email = oAuth2User.getAttribute("email");
+//        long userId = notifyService.findId(email);
 
         SseEmitter sseEmitter = notifyService.subscribe(email);
 
         return sseEmitter;
     }
     @ResponseBody
-    @GetMapping("/notify")
-    public List<NotifyDto> notify(Authentication authentication)
+    @GetMapping("/notify/{id}")
+    public List<NotifyDto> notify(Authentication authentication, @PathVariable Long id)
     {
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
         String email = oAuth2User.getAttribute("email");
-        return notifyService.notify(email);
+
+        return notifyService.notify(email, id);
     }
 }

--- a/src/main/java/com/example/density_check_web_service/domain/Notify/NotifyRepository.java
+++ b/src/main/java/com/example/density_check_web_service/domain/Notify/NotifyRepository.java
@@ -2,13 +2,19 @@ package com.example.density_check_web_service.domain.Notify;
 
 import com.example.density_check_web_service.domain.PiAddress.PiAddress;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import javax.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 
 public interface NotifyRepository extends JpaRepository<Notify, Long> {
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Notify n WHERE n.posts.id = :id")
+    void deleteByPostsId(@Param("id") Long id);
     @Query("SELECT n FROM Notify n WHERE n.users.email = :email")
     List<Notify> findAllByEmail(@Param("email") String email);
 }

--- a/src/main/java/com/example/density_check_web_service/service/NotifyService.java
+++ b/src/main/java/com/example/density_check_web_service/service/NotifyService.java
@@ -6,16 +6,22 @@ import com.example.density_check_web_service.domain.Notify.Notify;
 import com.example.density_check_web_service.domain.Notify.NotifyRepository;
 import com.example.density_check_web_service.domain.Notify.dto.NotifyDto;
 import com.example.density_check_web_service.domain.Posts.dto.PostsListResponseDto;
+import com.example.density_check_web_service.domain.Users.Users;
 import com.example.density_check_web_service.domain.Users.UsersRepository;
 import groovy.util.NodeList;
 import lombok.RequiredArgsConstructor;
 import org.apache.catalina.User;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -23,8 +29,13 @@ import java.util.stream.Collectors;
 public class NotifyService {
     private final NotifyRepository notifyRepository;
     private final UsersRepository usersRepository;
-    @Transactional
-    public List<NotifyDto> notify(String email) {
+    public static Map<String, SseEmitter> sseEmitters = new ConcurrentHashMap<>();
+
+    public List<NotifyDto> notify(String email, Long id) {
+        if (id != 0) {
+            notifyRepository.deleteByPostsId(id);
+            notifyRepository.flush();
+        }
         List<Notify> notify = notifyRepository.findAllByEmail(email);
         if (notify != null) {
             return notify.stream().map(NotifyDto::new).collect(Collectors.toList());
@@ -34,13 +45,10 @@ public class NotifyService {
         }
     }
 
-    @Transactional
     public SseEmitter subscribe(String email) {
 
-        long userId = usersRepository.findByEmail(email).get().getId();
-
-        if (NotifyController.sseEmitters.containsKey(userId)) {
-            return NotifyController.sseEmitters.get(userId);
+        if (sseEmitters.containsKey(email)) {
+            return sseEmitters.get(email);
         }
 
         // 현재 클라이언트를 위한 SseEmitter 생성
@@ -53,12 +61,24 @@ public class NotifyService {
         }
 
         // user의 pk값을 key값으로 해서 SseEmitter를 저장
-        NotifyController.sseEmitters.put(userId, sseEmitter);
+        sseEmitters.put(email, sseEmitter);
 
-        sseEmitter.onCompletion(() -> NotifyController.sseEmitters.remove(userId));
-        sseEmitter.onTimeout(() -> NotifyController.sseEmitters.remove(userId));
-        sseEmitter.onError((e) -> NotifyController.sseEmitters.remove(userId));
+        sseEmitter.onCompletion(() -> sseEmitters.remove(email));
+        sseEmitter.onTimeout(() -> sseEmitters.remove(email));
+        sseEmitter.onError((e) -> sseEmitters.remove(email));
 
         return sseEmitter;
     }
+
+//    @Async
+//    @EventListener
+//    public void catchEvent(Notify notify){
+//        Users user = notify.getUsers();
+//        SseEmitter sseEmitter = NotifyService.sseEmitters.get(user.getId());
+//        try {
+//            sseEmitter.send(SseEmitter.event().name("notification").data(new NotifyDto(notify)));
+//        } catch (Exception e) {
+//            NotifyService.sseEmitters.remove(user.getId());
+//        }
+//    }
 }

--- a/src/main/java/com/example/density_check_web_service/service/PostsService.java
+++ b/src/main/java/com/example/density_check_web_service/service/PostsService.java
@@ -48,11 +48,11 @@ public class PostsService {
             if (user.getId() != users.getId()) {
                 Notify notify = new Notify(posts, false, user);
                 notifyRepository.save(notify);
-                SseEmitter sseEmitter = NotifyController.sseEmitters.get(user.getId());
+                SseEmitter sseEmitter = NotifyService.sseEmitters.get(user.getEmail());
                 try {
                     sseEmitter.send(SseEmitter.event().name("notification").data(new NotifyDto(notify)));
                 } catch (Exception e) {
-                    NotifyController.sseEmitters.remove(user.getId());
+                    NotifyService.sseEmitters.remove(user.getEmail());
                 }
             }
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,5 @@ spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 spring.datasource.url=jdbc:h2:mem:testdb
 spring.profiles.include=oauth
+#logging.level.com.zaxxer.hikari.HikariConfig: DEBUG
+#logging.level.com.zaxxer.hikari: TRACE

--- a/src/main/resources/static/fragments/script.html
+++ b/src/main/resources/static/fragments/script.html
@@ -17,7 +17,7 @@
                     count = parseInt(count.slice(0,-1));
                     count++;
                     $("#count").text(count.toString() + "+");
-                    $("#notify").append("<a class=\"dropdown-item d-flex align-items-center\" href=\"#\">" +
+                    $("#notify").append("<a class=\"dropdown-item d-flex align-items-center\" href=\"/posts/" + message.posts.id + "\">" +
                         "                                    <div class=\"mr-3\">" +
                         "                                        <div class=\"icon-circle bg-warning\">" +
                         "                                            <i class=\"fas fa-exclamation-triangle text-white\"></i>" +
@@ -43,15 +43,20 @@
             }
         </script>
         <script sec:authorize="isAuthenticated()">
+            var current_url = window.location.pathname.split("/");
+            var id = 0;
+            if (current_url[1] == "posts") {
+                id = current_url[2];
+            }
             $.ajax({
                 type: "GET",
-                url: "/notify",
+                url: "/notify/" + id,
                 dataType: "json",
                 success: function(data) {
                     if (data) {
                         $("#count").text(data.length.toString() + "+");
                         $.each(data , function(i) {
-                            $("#notify").append("<a class=\"dropdown-item d-flex align-items-center\" href=\"#\">" +
+                            $("#notify").append("<a class=\"dropdown-item d-flex align-items-center\" href=\"/posts/" + data[i].posts.id + "\">" +
                                 "                                    <div class=\"mr-3\">" +
                                 "                                        <div class=\"icon-circle bg-warning\">" +
                                 "                                            <i class=\"fas fa-exclamation-triangle text-white\"></i>" +

--- a/src/main/resources/static/report.html
+++ b/src/main/resources/static/report.html
@@ -480,7 +480,6 @@
               html: true,
               trigger: "hover"
             });
-            notification();
         })
     </script>
 


### PR DESCRIPTION
sse를 이용한 알림 서비스를 구현하면서 DB Connection이 10개 이상으로 과해지며 서버가 중단되는 현상 발생하여 이유 분석 
1. sse 관련 service 단에서 transaction 어노테이션이 붙어있음 
2. sse는 transaction이 끝나도 DB 커넥션을 close 하지 않는데 새로 메서드에 접근할 때 마다 또 다시 DB Connection을 생성해서 발생하는 문제로 추측됨

sse 관련 service 단에서 transaction 어노테이션을 삭제해서 해결